### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:
@@ -31,7 +31,7 @@ repos:
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.931
     hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,10 +10,10 @@ resources:
       type: github
       endpoint: github
       name: asottile/azure-pipeline-templates
-      ref: refs/tags/v2.1.0
+      ref: refs/tags/v2.4.0
 
 jobs:
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [py36, py37]
+    toxenvs: [py37, py38, py39, py310]
     os: linux

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,13 +13,12 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
 py_modules = setup_py_upgrade
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [options.entry_points]
 console_scripts =

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from setuptools import setup
 setup()

--- a/setup_py_upgrade.py
+++ b/setup_py_upgrade.py
@@ -1,11 +1,11 @@
+from __future__ import annotations
+
 import argparse
 import ast
 import configparser
 import io
 import os.path
 from typing import Any
-from typing import Dict
-from typing import Optional
 from typing import Sequence
 
 METADATA_KEYS = frozenset((
@@ -47,11 +47,11 @@ def is_setuptools_attr_call(node: ast.Call, attr: str) -> bool:
 
 class Visitor(ast.NodeVisitor):
     def __init__(self) -> None:
-        self.sections: Dict[str, Dict[str, Any]] = {}
+        self.sections: dict[str, dict[str, Any]] = {}
         self.sections['metadata'] = {}
         self.sections['options'] = {}
 
-        self._files: Dict[str, str] = {}
+        self._files: dict[str, str] = {}
 
     def visit_With(self, node: ast.With) -> None:
         # with open("filename", ...) as fvar:
@@ -139,11 +139,11 @@ def _list_as_str(lst: Sequence[str]) -> str:
         return '\n' + '\n'.join(lst)
 
 
-def _dict_as_str(dct: Dict[str, str]) -> str:
+def _dict_as_str(dct: dict[str, str]) -> str:
     return _list_as_str([f'{k}={v}' for k, v in dct.items()])
 
 
-def _reformat(section: Dict[str, Any]) -> Dict[str, Any]:
+def _reformat(section: dict[str, Any]) -> dict[str, Any]:
     new_section = {}
     for key, value in section.items():
         if isinstance(value, (list, tuple)):
@@ -155,7 +155,7 @@ def _reformat(section: Dict[str, Any]) -> Dict[str, Any]:
     return new_section
 
 
-def main(argv: Optional[Sequence[str]] = None) -> int:
+def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('directory')
     args = parser.parse_args(argv)

--- a/tests/setup_py_upgrade_test.py
+++ b/tests/setup_py_upgrade_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from setup_py_upgrade import main

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,pre-commit
+envlist = py37,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos